### PR TITLE
Minor fixes to use the latest version of node_exporter and prometheus.

### DIFF
--- a/node_exporter/contrib/node_exporter.conf
+++ b/node_exporter/contrib/node_exporter.conf
@@ -1,8 +1,0 @@
-{
-    "collectors": {
-        "enabled": "diskstats,filesystem,loadavg,meminfo,stat,netdev,netstat,lastlogin"
-    },
-    "web": {
-        "listen": 9092
-    }
-}

--- a/node_exporter/contrib/node_exporter.init
+++ b/node_exporter/contrib/node_exporter.init
@@ -13,7 +13,6 @@
 
 RETVAL=0
 PROG="node_exporter"
-DAEMON_CONFIG=/etc/prometheus/${PROG}.conf
 DAEMON_SYSCONFIG=/etc/sysconfig/${PROG}
 DAEMON=/usr/bin/${PROG}
 PID_FILE=/var/run/prometheus/${PROG}.pid

--- a/node_exporter/contrib/node_exporter.spec
+++ b/node_exporter/contrib/node_exporter.spec
@@ -27,10 +27,8 @@ mkdir -vp $RPM_BUILD_ROOT/var/run/prometheus
 mkdir -vp $RPM_BUILD_ROOT/var/lib/prometheus
 mkdir -vp $RPM_BUILD_ROOT/usr/bin
 mkdir -vp $RPM_BUILD_ROOT/etc/init.d
-mkdir -vp $RPM_BUILD_ROOT/etc/prometheus
 mkdir -vp $RPM_BUILD_ROOT/etc/sysconfig
 install -m 755 node_exporter $RPM_BUILD_ROOT/usr/bin/node_exporter
-install -m 644 contrib/node_exporter.conf $RPM_BUILD_ROOT/etc/prometheus/node_exporter.conf
 install -m 755 contrib/node_exporter.init $RPM_BUILD_ROOT/etc/init.d/node_exporter
 install -m 644 contrib/node_exporter.sysconfig $RPM_BUILD_ROOT/etc/sysconfig/node_exporter
 
@@ -53,7 +51,6 @@ chmod 744 /var/log/prometheus
 %files
 %defattr(-,root,root,-)
 /usr/bin/node_exporter
-%config(noreplace) /etc/prometheus/node_exporter.conf
 /etc/init.d/node_exporter
 %config(noreplace) /etc/sysconfig/node_exporter
 /var/run/prometheus

--- a/node_exporter/contrib/node_exporter.sysconfig
+++ b/node_exporter/contrib/node_exporter.sysconfig
@@ -2,21 +2,16 @@
 #  -alsologtostderr=false: log to standard error as well as files
 #  -auth.pass="": Password for basic auth.
 #  -auth.user="": Username for basic auth.
-#  -collector.diskstats.ignored-devices="^(ram|loop|fd|(h|s|v|xv)d[a-z])\\d+$": Regexp of devices to ignore for diskstats.
-#  -collector.filesystem.ignored-mount-points="^/(sys|proc|dev)($|/)": Regexp of mount points to ignore for filesystem collector.
-#  -collector.ntp.server="": NTP server to use for ntp collector.
-#  -collector.textfile.directory="": Directory to read text files with metrics from.
-#  -collectors.enabled="attributes,diskstats,filesystem,loadavg,meminfo,stat,textfile,time,netdev,netstat": Comma-separated list of collectors to use.
+#  -collectors.enabled="diskstats,filesystem,loadavg,meminfo,stat,textfile,time,netdev,netstat,lastlogin": Comma-separated list of collectors to use.
 #  -collectors.print=false: If true, print available collectors and exit.
-#  -config.file="": Path to config file.
 #  -debug.memprofile-file="": Write memory profile to this file upon receipt of SIGUSR1.
-#  -log_backtrace_at=:0: when logging hits line file:N, emit a stack trace
-#  -log_dir="": If non-empty, write log files in this directory
-#  -logtostderr=false: log to standard error instead of files
-#  -stderrthreshold=0: logs at or above this threshold go to stderr
-#  -v=0: log level for V logs
-#  -vmodule=: comma-separated list of pattern=N settings for file-filtered logging
 #  -web.listen-address=":9100": Address on which to expose metrics and web interface.
 #  -web.telemetry-path="/metrics": Path under which to expose metrics.
+#  -collector.ntp.server="": NTP server to use for ntp collector.
+#  -collector.textfile.directory="": Directory to read text files with metrics from.
+#  -collector.megacli.command="megacli": Command to run megacli.
+#  -collector.filesystem.ignored-mount-points="^/(sys|proc|dev)($|/)": Regexp of mount points to ignore for filesystem collector.
+#  -collector.ipvs.procfs="": procfs mountpoint.
+#  -collector.diskstats.ignored-devices="^(ram|loop|fd|(h|s|v|xv)d[a-z])\\d+$": Regexp of devices to ignore for diskstats.
 
-ARGS="-config.file=/etc/prometheus/node_exporter.conf -log_dir=/var/log/prometheus"
+ARGS="-collectors.enabled=diskstats,filesystem,loadavg,meminfo,stat,textfile,time,netdev,netstat,lastlogin"

--- a/prometheus/contrib/prometheus.spec
+++ b/prometheus/contrib/prometheus.spec
@@ -102,3 +102,5 @@ chmod 744 /var/log/prometheus
 /usr/share/prometheus/consoles/node.html
 /usr/share/prometheus/console_libraries/prom.lib
 /usr/share/prometheus/console_libraries/menu.lib
+/var/run/prometheus
+/var/log/prometheus

--- a/prometheus/contrib/prometheus.sysconfig
+++ b/prometheus/contrib/prometheus.sysconfig
@@ -107,4 +107,4 @@
 #  -web.user-assets=""
 #      Path to static asset directory, available at /user.
 
-ARGS="-config.file=/etc/prometheus/prometheus.yaml -log_dir=/var/log/prometheus -web.console.libraries=/usr/share/prometheus/console_libraries -web.console.templates=/usr/share/prometheus/consoles"
+ARGS="-config.file=/etc/prometheus/prometheus.yaml -web.console.libraries=/usr/share/prometheus/console_libraries -web.console.templates=/usr/share/prometheus/consoles"


### PR DESCRIPTION
First of all thanks for sharing, it really saved me a lot of time today. I just wanted to contribute back with the changes I made to get it working with node_exporter 0.10.0 and Prometheus 0.14.0. Namely removed -log_dir flag from both and -config.file from node_exporter. Tested on Amazon linux 2015.03.