### PR TITLE
remove bad argument log_dir

### DIFF
--- a/prometheus/contrib/prometheus.sysconfig
+++ b/prometheus/contrib/prometheus.sysconfig
@@ -107,4 +107,4 @@
 #  -web.user-assets=""
 #      Path to static asset directory, available at /user.
 
-ARGS="-config.file=/etc/prometheus/prometheus.yaml -log_dir=/var/log/prometheus -web.console.libraries=/usr/share/prometheus/console_libraries -web.console.templates=/usr/share/prometheus/consoles"
+ARGS="-config.file=/etc/prometheus/prometheus.yaml -web.console.libraries=/usr/share/prometheus/console_libraries -web.console.templates=/usr/share/prometheus/consoles"


### PR DESCRIPTION
The sysconfig file includes a bad option that prevents the service from starting.

```bash
root@vagrant prometheus # prometheus --version
prometheus, version 0.16.0 (branch: HEAD, revision: dcb8ba4)
  build user:       julius@desktop
  build date:       20151009-23:51:17
  go version:       1.5.1
root@vagrant prometheus # prometheus -h |grep log
   -log.level "info"
      Only log messages with the given severity or above. Valid levels:
```